### PR TITLE
Fix potential leak of colorSpace

### DIFF
--- a/ColorCube/ColorCube/CCColorCube.m
+++ b/ColorCube/ColorCube/CCColorCube.m
@@ -513,14 +513,14 @@ int neighbourIndices[27][3] = {
     NSUInteger width = CGImageGetWidth(cgImage);
     NSUInteger height = CGImageGetHeight(cgImage);
 
-    // Create the color space
-    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-
     // Allocate storage for the pixel data
     unsigned char *rawData = (unsigned char *)malloc(height * width * 4);
 
     // If allocation failed, return NULL
     if (!rawData) return NULL;
+
+    // Create the color space
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
 
     // Set some metrics
     NSUInteger bytesPerPixel = 4;


### PR DESCRIPTION
Trivial fix for a static analysis warning of a potential leak. If
the malloc failed and the method aborted, colorSpace would not be
freed. Fix by only creating the color space after the malloc
succeeds.
