### PR TITLE
Python command line guard and passing other default value

### DIFF
--- a/Python/ColorCube.py
+++ b/Python/ColorCube.py
@@ -50,19 +50,19 @@ class CubeCell:
 class ColorCube:
 	# Uses a 3d RGB histogram to find local maximas in the density distribution
 	# in order to retrieve dominant colors of pixel images
-	def __init__(self, resolution=30, avoid_color=None):
+	def __init__(self, resolution=30, avoid_color=None, distinct_threshold=0.2, bright_threshold=0.6):
 		
 		# Keep resolution
 		self.resolution = resolution
 
 		# Threshold for distinct local maxima
-		self.distinct_threshold = 0.2
+		self.distinct_threshold = distinct_threshold
 
 		# Color to avoid
 		self.avoid_color = avoid_color
 
 		# Colors that are darker than this go away		
-		self.bright_threshold = 0.6
+		self.bright_threshold = bright_threshold
 
 		# Helper variable to have cell count handy
 		self.cell_count = resolution * resolution * resolution
@@ -285,20 +285,26 @@ class ColorCube:
 		return result
 
 ##############################################################################################################################
+# Command line example
+if __name__ == "__main__":
+	import argparse
+	parser = argparse.ArgumentParser(description='Get dominant color of an image.')
+	parser.add_argument('image', help='Image to process')
+	args = parser.parse_args()
 
-# Create color cube, avoiding resulting colors that are too close to white.
-cc = ColorCube(avoid_color=[255, 255, 255])
+	# Create color cube, avoiding resulting colors that are too close to white.
+	cc = ColorCube(avoid_color=[255, 255, 255])
 
-# Load image and scale down to make the algorithm faster.
-# Scaling down also gives colors that are more dominant in perception.
-image = Image.open('berlin.jpg').resize((50, 50))
+	# Load image and scale down to make the algorithm faster.
+	# Scaling down also gives colors that are more dominant in perception.
+	image = Image.open(args.image).resize((50, 50))
 
-# Get colors for that image
-colors = cc.get_colors(image)
-
-# Print first four colors (there might be much more)
-for c in colors[:10]:
-	print(c)
+	# Get colors for that image
+	colors = cc.get_colors(image)
+	
+	# Print first four colors (there might be much more)
+	for c in colors[:10]:
+		print(c)
 
 
 

--- a/Python/ColorCube.py
+++ b/Python/ColorCube.py
@@ -284,7 +284,7 @@ class ColorCube:
         	
 		return result
 
-##############################################################################################################################
+################################################################################
 # Command line example
 if __name__ == "__main__":
 	import argparse
@@ -305,13 +305,3 @@ if __name__ == "__main__":
 	# Print first four colors (there might be much more)
 	for c in colors[:10]:
 		print(c)
-
-
-
-
-
-
-
-
-
-

--- a/Python/ColorCube.py
+++ b/Python/ColorCube.py
@@ -288,8 +288,8 @@ class ColorCube:
 # Command line example
 if __name__ == "__main__":
 	import argparse
-	parser = argparse.ArgumentParser(description='Get dominant color of an image.')
-	parser.add_argument('image', help='Image to process')
+	parser = argparse.ArgumentParser(description='Get dominant colors of an image.')
+	parser.add_argument('image', help='Image file to process.')
 	args = parser.parse_args()
 
 	# Create color cube, avoiding resulting colors that are too close to white.

--- a/Python/README
+++ b/Python/README
@@ -1,1 +1,5 @@
-Just go 'python ColorCube.py' to see the example results.
+For example run:
+
+```
+$ python ColorCube.py berlin.jpg
+```


### PR DESCRIPTION
## Defect

The Python script currently always attempts to open `berlin.jpg` when run. This was a problem when I tried to use ColorCube as a library.

Also, there are a few hard coded parameters in the python script that should be exposed to the user. I was passing in an all black image and wondering why the results were empty when I expected a black result color. Control of `bright_threshold` allows this behavior to be changed by the user.
## Fix
- Add a `if __name__ == "__main__":` guard to run example.
- Use `argparse` for the example instead of hardcoded image name.
- Take `distinct_threshold` and `bright_threshold` as kwargs instead. 
