### PR TITLE
fix build error.

### DIFF
--- a/ColorCube/ColorCube/CCColorCube.h
+++ b/ColorCube/ColorCube/CCColorCube.h
@@ -19,7 +19,7 @@
 //  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 // Flags that determine how the colors are extract
 typedef enum CCFlags: NSUInteger


### PR DESCRIPTION
I was working the ColorCube to my iOS projects, build error has occurred. Issue a precompiled header xcode has occurred in order to no longer actively support. ColorCube still is wonderful, but I would like you to merge this fix.
