### PR TITLE
Fixed TypeError 'int' object is not iterable edge case when object is 0.

### DIFF
--- a/Python/ColorCube.py
+++ b/Python/ColorCube.py
@@ -145,7 +145,8 @@ class ColorCube:
 
 		# Iterate over all pixels of the image
 		for p in image.getdata(): 
-
+			if p == 0:
+				break
 			# Get color components
 			r = float(p[0])/255.0
 			g = float(p[1])/255.0


### PR DESCRIPTION
![Screen Shot 2020-08-08 at 4 27 14 PM](https://user-images.githubusercontent.com/6313979/90685237-81fad700-e237-11ea-85c1-0f152e22b668.png)
Found an edge case in the python version of the program. Sometimes an image would be 0 for pixel colors when normally it would be lists of colors for the pixels for example (245,245,245)... etc. I have a screenshot that does a better job of explaining this where I would print what is going on. This two line fix I included seems to keep things running smooth without aborting the entire process for bulk import cases like this. Appreciate the software! Very handy right now for my project.